### PR TITLE
Fix bug when txp isn't defined

### DIFF
--- a/loramon/loramon.py
+++ b/loramon/loramon.py
@@ -540,7 +540,7 @@ def main():
 				print("Bandwidth in Hz:\t", end=' ')
 				rnode.bandwidth = int(input())
 
-			if args.txp >= 0 and args.txp <= 17:
+			if args.txp and (args.txp >= 0 and args.txp <= 17):
 				rnode.txpower = args.txp
 			else:
 				rnode.txpower = 0


### PR DESCRIPTION
This fixes a small bug when `--txp` wasn't defined but used.