### PR TITLE
Add an option for specifying duration of capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This utility allows you to sniff LoRa networks with an [RNode](https://unsigned.
 ```sh
 usage: loramon [-h] [-C] [-W directory] [--freq Hz] [--bw Hz] [--txp dBm]
                [--sf factor] [--cr rate]
+               [--duration seconds] [-Q]
                [port]
 
 LoRa packet sniffer for RNode hardware.
@@ -23,6 +24,8 @@ optional arguments:
   --txp dBm      TX power in dBm
   --sf factor    Spreading factor
   --cr rate      Coding rate
+  --duration s   Duration to scan for in seconds
+  --Q            Quite mode. Don't log any messages after start up
 ```
 
 ## Installation

--- a/loramon/channel_scanner.py
+++ b/loramon/channel_scanner.py
@@ -10,12 +10,13 @@ freq_step  =    125000
 spreading_factor_table = [7, 8, 9, 10, 11, 12]
 coding_rate_tabel = [5, 8]
 
-scan_duration = 1
+scan_duration = 2
 
 #print header
 print(" Frequency, Bandwidth, Spread Factor, Coding Rate, Duration, Captured Packets")
 
 for freq in range(freq_start, freq_end, freq_step):
+    print(f"{freq}")
     for sf in spreading_factor_table:
         for cr in coding_rate_tabel:
             command = ['python3', 'loramon.py']
@@ -38,13 +39,15 @@ for freq in range(freq_start, freq_end, freq_step):
                 #Uncomment this to see the command we run
                 #print(f"{command}")
                 result = subprocess.run(command)
-                print("{:>{}} {:>{}} {:>{}} {:>{}} {:>{}} {:>{}}".format(
-                                                freq, 10, 
-                                                freq_step, 10, 
-                                                sf, 14, 
-                                                cr, 12, 
-                                                scan_duration, 9, 
-                                                result.returncode, 14))
+                if result.returncode > 0:
+                    print()
+                    print("{:>{}} {:>{}} {:>{}} {:>{}} {:>{}} {:>{}}".format(
+                                                    freq, 10, 
+                                                    freq_step, 10, 
+                                                    sf, 14, 
+                                                    cr, 12, 
+                                                    scan_duration, 9, 
+                                                    result.returncode, 14))
                 #print(f"{freq}, {freq_step}, {sf}, {cr}, {scan_duration}, {result.returncode}")
             except subprocess.CalledProcessError as e:
                 print(f"Failed to launch {command} with error {e}")

--- a/loramon/channel_scanner.py
+++ b/loramon/channel_scanner.py
@@ -1,0 +1,50 @@
+import subprocess
+
+# Parameters from: https://meshtastic.org/docs/overview/radio-settings/
+
+serial_port = "/dev/ttyUSB0"
+freq_start = 902000000
+freq_end   = 928000000
+freq_step  =    125000
+
+spreading_factor_table = [7, 8, 9, 10, 11, 12]
+coding_rate_tabel = [5, 8]
+
+scan_duration = 1
+
+#print header
+print(" Frequency, Bandwidth, Spread Factor, Coding Rate, Duration, Captured Packets")
+
+for freq in range(freq_start, freq_end, freq_step):
+    for sf in spreading_factor_table:
+        for cr in coding_rate_tabel:
+            command = ['python3', 'loramon.py']
+            command.append(serial_port)
+            command.append("--freq")
+            command.append(str(freq))
+            command.append("--bw")
+            command.append(str(freq_step))
+            command.append("--sf")
+            command.append(str(sf))
+            command.append("--cr")
+            command.append(str(cr))
+            command.append("-C")
+            command.append("--duration")
+            command.append(str(scan_duration))
+            command.append("-Q") #disable logging
+
+            # Run the command
+            try:
+                #Uncomment this to see the command we run
+                #print(f"{command}")
+                result = subprocess.run(command)
+                print("{:>{}} {:>{}} {:>{}} {:>{}} {:>{}} {:>{}}".format(
+                                                freq, 10, 
+                                                freq_step, 10, 
+                                                sf, 14, 
+                                                cr, 12, 
+                                                scan_duration, 9, 
+                                                result.returncode, 14))
+                #print(f"{freq}, {freq_step}, {sf}, {cr}, {scan_duration}, {result.returncode}")
+            except subprocess.CalledProcessError as e:
+                print(f"Failed to launch {command} with error {e}")

--- a/loramon/channel_scanner.py
+++ b/loramon/channel_scanner.py
@@ -8,27 +8,29 @@ freq_end   = 928000000
 freq_step  =    125000
 
 spreading_factor_table = [7, 8, 9, 10, 11, 12]
-coding_rate_tabel = [5, 8]
+bandwidth_table = [125000, 250000]
+#pass a coding rate, although it doesn't really matter since LoraMon is RX only
+coding_rate = 5
 
 scan_duration = 2
 
+
 #print header
-print(" Frequency, Bandwidth, Spread Factor, Coding Rate, Duration, Captured Packets")
+print(" Frequency, Bandwidth, Spread Factor, Duration, Captured Packets")
 
 for freq in range(freq_start, freq_end, freq_step):
-    print(f"{freq}")
-    for sf in spreading_factor_table:
-        for cr in coding_rate_tabel:
+    for bw in bandwidth_table:
+        for sf in spreading_factor_table:
             command = ['python3', 'loramon.py']
             command.append(serial_port)
             command.append("--freq")
             command.append(str(freq))
             command.append("--bw")
-            command.append(str(freq_step))
+            command.append(str(bw))
             command.append("--sf")
             command.append(str(sf))
             command.append("--cr")
-            command.append(str(cr))
+            command.append(str(coding_rate))
             command.append("-C")
             command.append("--duration")
             command.append(str(scan_duration))
@@ -39,15 +41,11 @@ for freq in range(freq_start, freq_end, freq_step):
                 #Uncomment this to see the command we run
                 #print(f"{command}")
                 result = subprocess.run(command)
-                if result.returncode > 0:
-                    print()
-                    print("{:>{}} {:>{}} {:>{}} {:>{}} {:>{}} {:>{}}".format(
-                                                    freq, 10, 
-                                                    freq_step, 10, 
-                                                    sf, 14, 
-                                                    cr, 12, 
-                                                    scan_duration, 9, 
-                                                    result.returncode, 14))
-                #print(f"{freq}, {freq_step}, {sf}, {cr}, {scan_duration}, {result.returncode}")
+                print("{:>{}} {:>{}} {:>{}} {:>{}} {:>{}}".format(
+                                                freq, 10, 
+                                                bw, 10, 
+                                                sf, 14, 
+                                                scan_duration, 9, 
+                                                result.returncode, 14))
             except subprocess.CalledProcessError as e:
                 print(f"Failed to launch {command} with error {e}")

--- a/loramon/loramon.py
+++ b/loramon/loramon.py
@@ -537,7 +537,7 @@ def main():
 			rnode.duration_to_capture_for = args.duration
 
 			thread = threading.Thread(target=rnode.readLoop)
-			thread.setDaemon(True)
+			thread.daemon = True
 			thread.start()
 
 			try:


### PR DESCRIPTION
Based on this discussion:
https://github.com/markqvist/Reticulum/discussions/785
I thought it was a good feature to specify duration of capture. The usefulness of this option is for writing a wrapper script for scanning frequencies and other settings.
The provided channel_scanner is a  wrapper scripts that steps through parameters, calls loramon, and then records the results as a CSV printout.
The parameters are based on Meshtastic channels, spreading factor, and coding rates defined here: https://meshtastic.org/docs/overview/radio-settings/.

The minor annoyance is that exit codes are limited to a byte in Linux, so the return value is capped to 255.